### PR TITLE
Fixed not being able to display fonts loaded from files

### DIFF
--- a/src/TypefaceUtil.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TypefaceUtil.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -293,6 +293,7 @@ namespace TypefaceUtil.Avalonia.ViewModels
                     }
                 }
             }
+            typefaceViewModel.Typeface.Dispose();
         }
 
         private void OpenGlyphDetail(GlyphViewModel glyphViewModel)
@@ -336,7 +337,7 @@ namespace TypefaceUtil.Avalonia.ViewModels
         {
             if (!string.IsNullOrEmpty(path))
             {
-                using var typeface = SKTypeface.FromFile(path);
+                var typeface = SKTypeface.FromFile(path);
                 if (typeface != null)
                 {
                     var characterMaps = Read(typeface);


### PR DESCRIPTION
Fix in the LoadGlyphs method, the premature release of Typeface caused the font data loaded from the file to be unable to be displayed.